### PR TITLE
Move Beam to privacy coins

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Currencies focusing on privacy.
 - Zcoin
 - Particle [[src]](https://github.com/particl) [[r]](https://reddit.com/r/Particl)
 - Verge [[src]](https://github.com/vergecurrency) [[r]](https://reddit.com/r/vergecurrency)
+- Beam [[src]](https://github.com/BeamMW) [[w]](https://beam.mw)
 
 ### Oracle Coins
 
@@ -148,11 +149,6 @@ Currencies focusing on privacy.
 - Nano
 - Fantom
 - Perlin (Avalanche consensus, WASM based contracts)
-
-### Mimblewimble
-
-- Grin
-- Beam
 
 ## Resources
 


### PR DESCRIPTION
As much as I would prefer Grin to be the one awesome new privacy coin, I
believe Beam is has a good chance of actually getting there in a much
much faster time. They are producing results.

Among others, most dominant work in progress is the merger with of
[Lelantus and Mimblewimble](https://github.com/BeamMW/beam/wiki/Lelantus-MW), i.e. the
new ZCoin protocol and Mimblewimble. While anonymity-set might be not as
high as ZCash, the simplicity of the protocol and the already strong
promises of either protocol make this the goto technology for privacy in
the future. IMHO. Of course, I can only look into so many communities.